### PR TITLE
Limit bucket operations on created user

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Unreleased
 ==========
 
 * Update README.
+* Set more restrictive S3 permissions on bucket users.
 
 0.1a0 - 20th June 2018
 ======================

--- a/buckup/bucket_creator.py
+++ b/buckup/bucket_creator.py
@@ -135,18 +135,32 @@ class BucketCreator:
                 "Version": "2012-10-17",
                 "Statement": [
                     {
-                        "Sid": "AllowFullBucketAccess",
+                        "Sid": "AllowApplicationBucketAccess",
                         "Effect": "Allow",
-                        "Action": ["s3:*"],
+                        "Action": [
+                            "s3:ListBucket",
+                            "s3:GetBucketLocation",
+                            "s3:ListBucketMultipartUploads",
+                            "s3:ListBucketVersions",
+                        ],
                         "Resource": [
                             "arn:aws:s3:::{bucket_name}".format(
                                 bucket_name=bucket.name
                             ),
+                        ],
+                    },
+                    {
+                        "Sid": "AllowApplicationObjectAccess",
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:*",
+                        ],
+                        "Resource": [
                             "arn:aws:s3:::{bucket_name}/*".format(
                                 bucket_name=bucket.name
                             ),
-                        ]
-                    }
+                        ],
+                    },
                 ]
             }),
         )


### PR DESCRIPTION
Don't allow crated user to list other buckets or delete its own bucket or manipulate other settings like changing ACLs or versioning of the bucket. App should only need to list bucket or request its location, but not change anything...

Allow all object level permissions since that seems harmless.