### PR TITLE
Add version argument

### DIFF
--- a/buckup/__init__.py
+++ b/buckup/__init__.py
@@ -1,0 +1,3 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version("buckup")

--- a/buckup/command_line.py
+++ b/buckup/command_line.py
@@ -8,6 +8,7 @@ from .exceptions import (
 )
 
 from .utils import CommandLineInterface
+from . import __version__
 
 
 USER_NAME_FORMAT = '{bucket_name}-s3-owner'
@@ -209,6 +210,12 @@ class BuckupCommandLineInterface(CommandLineInterface):
 def parse_args():
     parser = argparse.ArgumentParser(
         description='Create S3 bucket with user ready to use on your website.'
+    )
+    parser.add_argument(
+        "--version",
+        help="Show version",
+        action="version",
+        version=__version__
     )
     parser.add_argument('--profile', type=str,
                         help='AWS CLI profile you want to use')


### PR DESCRIPTION
This makes it easier to determine what version of `buckup` is being used.

We intentionally read it out of `importlib` to avoid duplicating the version number and risking it getting out of sync.