### PR TITLE
Allow control of public ACLs

### DIFF
--- a/buckup/bucket_creator.py
+++ b/buckup/bucket_creator.py
@@ -29,6 +29,7 @@ class BucketCreator:
         self.set_bucket_policy(
             bucket,
             user,
+            allow_public_acls=data["allow_public_acls"],
             public_get_object_paths=data.get('public_get_object_paths')
         )
         if data.get('cors_origins'):
@@ -94,7 +95,7 @@ class BucketCreator:
             )
         }
 
-    def set_bucket_policy(self, bucket, user, public_get_object_paths=None):
+    def set_bucket_policy(self, bucket, user, allow_public_acls, public_get_object_paths=None):
         policy_statement = []
         public_access = bool(public_get_object_paths)
 
@@ -125,19 +126,19 @@ class BucketCreator:
                 break
         print('Bucket policy set.')
 
-        if public_access:
-            # NB: This API doesn't exist on a `Bucket`
-            self.s3_client.put_public_access_block(
-                Bucket=bucket.name,
-                # Allow policies to provide access to objects, but not ACLs
-                PublicAccessBlockConfiguration={
-                    "BlockPublicAcls": True,
-                    "IgnorePublicAcls": True,
-                    "BlockPublicPolicy": False,
-                    "RestrictPublicBuckets": False
-                }
-            )
-            print('Enabled public access to the bucket.')
+        # NB: This API doesn't exist on a `Bucket`
+        self.s3_client.put_public_access_block(
+            Bucket=bucket.name,
+            PublicAccessBlockConfiguration={
+                # Prevent files being marked as public using ACLs
+                "BlockPublicAcls": not allow_public_acls,
+                "IgnorePublicAcls": not allow_public_acls,
+                # Allow policies to allow public access to objects
+                "BlockPublicPolicy": not public_access,
+                "RestrictPublicBuckets": not public_access
+            }
+        )
+        print('Configured public access to bucket.')
 
     def create_bucket(self, name, region):
         """

--- a/buckup/bucket_creator.py
+++ b/buckup/bucket_creator.py
@@ -130,15 +130,15 @@ class BucketCreator:
         self.s3_client.put_public_access_block(
             Bucket=bucket.name,
             PublicAccessBlockConfiguration={
-                # Prevent files being marked as public using ACLs
                 "BlockPublicAcls": not allow_public_acls,
                 "IgnorePublicAcls": not allow_public_acls,
-                # Allow policies to allow public access to objects
                 "BlockPublicPolicy": not public_access,
                 "RestrictPublicBuckets": not public_access
             }
         )
-        print('Configured public access to bucket.')
+
+        if public_access or allow_public_acls:
+            print('Configured public access to bucket.')
 
     def create_bucket(self, name, region):
         """

--- a/buckup/command_line.py
+++ b/buckup/command_line.py
@@ -170,7 +170,7 @@ class BuckupCommandLineInterface(CommandLineInterface):
     def ask_public_acl(self):
         self.data['allow_public_acls'] = self.ask_yes_no(
             'Do you want to allow public ACLs on objects?\n'
-            'This allows individual files to be public rather than paths.'
+            'This allows access to individual objects to be controlled separately from the bucket policy.'
         )
 
     def ask_cors(self):

--- a/buckup/command_line.py
+++ b/buckup/command_line.py
@@ -167,6 +167,12 @@ class BuckupCommandLineInterface(CommandLineInterface):
                 break
         self.data['public_get_object_paths'] = paths
 
+    def ask_public_acl(self):
+        self.data['allow_public_acls'] = self.ask_yes_no(
+            'Do you want to allow public ACLs on objects?\n'
+            'This allows individual files to be public rather than paths.'
+        )
+
     def ask_cors(self):
         cors_origins = self.ask(
             'Specify a comma separated list of origins whitelisted for the '
@@ -199,6 +205,7 @@ class BuckupCommandLineInterface(CommandLineInterface):
         self.ask_user_name()
         self.ask_enable_versioning()
         self.ask_public_get_object()
+        self.ask_public_acl()
         self.ask_cors()
         self.print_separator()
         if self.ask_summary():


### PR DESCRIPTION
Certain use cases require public ACLs, such as `wagtail-storages`.

Rather than assuming what the user wants, I've added another check as to whether a user wants public ACLs enabled or not. Public policies is linked to whether the user provides paths, meaning fully private buckets can now be marked so by AWS.