### PR TITLE
Require HTTPS

### DIFF
--- a/buckup/command_line.py
+++ b/buckup/command_line.py
@@ -185,12 +185,6 @@ class BuckupCommandLineInterface(CommandLineInterface):
             if origin:
                 self.data['cors_origins'].append(origin)
 
-    def ask_https(self):
-        self.data['require_https'] = self.ask_yes_no(
-            'Do you want to only allow access over HTTPS?\n'
-            'WARNING: This will not redirect! Unsecured HTTP requests will fail.',
-        )
-
     def create_bucket(self):
         self.bucket_creator.commit(self.data)
         self.print_separator()
@@ -212,7 +206,6 @@ class BuckupCommandLineInterface(CommandLineInterface):
         self.ask_user_name()
         self.ask_enable_versioning()
         self.ask_public_get_object()
-        self.ask_https()
         self.ask_public_acl()
         self.ask_cors()
         self.print_separator()

--- a/buckup/command_line.py
+++ b/buckup/command_line.py
@@ -185,6 +185,12 @@ class BuckupCommandLineInterface(CommandLineInterface):
             if origin:
                 self.data['cors_origins'].append(origin)
 
+    def ask_https(self):
+        self.data['require_https'] = self.ask_yes_no(
+            'Do you want to only allow access over HTTPS?\n'
+            'WARNING: This will not redirect! Unsecured HTTP requests will fail.',
+        )
+
     def create_bucket(self):
         self.bucket_creator.commit(self.data)
         self.print_separator()
@@ -206,6 +212,7 @@ class BuckupCommandLineInterface(CommandLineInterface):
         self.ask_user_name()
         self.ask_enable_versioning()
         self.ask_public_get_object()
+        self.ask_https()
         self.ask_public_acl()
         self.ask_cors()
         self.print_separator()


### PR DESCRIPTION
HTTPS is now required for API access, too.

Sadly, there's no way to have S3 redirect to HTTPS instead. Chances are, S3 is running behind some kind of proxy for serving files, which itself would handle the redirect.